### PR TITLE
refactor: consolidate hop counting to agent_hops only

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,7 +63,6 @@ CADENCE_MAX_SESSION_HISTORY=100
 
 # --- Processing Configuration ---
 CADENCE_MAX_AGENT_HOPS=25
-CADENCE_MAX_TOOL_HOPS=50
 CADENCE_GRAPH_RECURSION_LIMIT=100
 
 # --- SDK Hybrid Plugin Discovery (optional; echo_sdk utilities) ---

--- a/README.md
+++ b/README.md
@@ -134,7 +134,6 @@ CADENCE_DEBUG=true
 
 # Advanced Configuration
 CADENCE_MAX_AGENT_HOPS=25
-CADENCE_MAX_TOOL_HOPS=50
 CADENCE_GRAPH_RECURSION_LIMIT=50
 
 # Session Management
@@ -226,7 +225,7 @@ class MyPlugin(BasePlugin):
             description="My custom AI agent",
             capabilities=["custom_task"],
             agent_type="specialized",
-            dependencies=["cadence_sdk>=1.0.1,<2.0.0"],
+            dependencies=["cadence_sdk>=1.0.2,<2.0.0"],
         )
 
     @staticmethod

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -136,12 +136,12 @@ Manages connections to various language models:
 Cadence aggregates plugins from two sources at startup:
 
 - Pip-installed packages (environment packages)
-    - Discovered via the SDK registry when packages that depend on `cadence_sdk` are present
-    - Import of the package triggers `register_plugin(...)`
-    - No extra configuration needed beyond having the package installed
+  - Discovered via the SDK registry when packages that depend on `cadence_sdk` are present
+  - Import of the package triggers `register_plugin(...)`
+  - No extra configuration needed beyond having the package installed
 
 - Directory-based packages (filesystem)
-    - Controlled via environment variable `CADENCE_PLUGINS_DIR`
+  - Controlled via environment variable `CADENCE_PLUGINS_DIR`
 
 ```bash
 # Single directory
@@ -269,7 +269,7 @@ flowchart LR
     ToolNode --> AgentNode
     AgentNode -- "should_continue = back" --> Coordinator
     Coordinator --> ToolNode
-    ToolNode -- "hop limit reached" --> SuspendNode
+    ToolNode -- "agent hop limit reached" --> SuspendNode
     ToolNode -- "normal routing" --> AgentNode
     SuspendNode --> Finalizer
 ```
@@ -292,9 +292,18 @@ The suspend node provides intelligent handling of hop limits:
 - **Preserves context** across the limit boundary
 
 When hop limits are reached, the workflow automatically routes through:
-`ToolNode → SuspendNode → Finalizer → END`
+`ToolNode → SuspendNode → Finalizer → DONE`
 
 This ensures the AI can communicate with users about incomplete processing and provide helpful context.
+
+#### Coordinator Response Enforcement
+
+The coordinator now enforces proper routing by ensuring all responses go through the finalizer node:
+
+- **No Direct Answers**: The coordinator never answers questions directly
+- **Consistent Flow**: All responses route through the finalizer for proper synthesis
+- **Content Cleanup**: Removes any direct response content from the coordinator
+- **Proper Routing**: Maintains the intended conversation flow through the finalizer
 
 #### Core Wiring (excerpt)
 

--- a/docs/concepts/langgraph-architecture.md
+++ b/docs/concepts/langgraph-architecture.md
@@ -46,7 +46,7 @@ graph TB
     subgraph "Infrastructure Layer"
         Q[State Management] --> R[LLM Factory]
         S[Plugin Manager] --> T[Graph Builder]
-        U[ToolExecutionLogger] --> V[Hop Counting]
+        U[ToolExecutionLogger] --> V[Agent Hop Counting]
         W[Message Filtering] --> X[Safety Validation]
     end
 ```
@@ -86,7 +86,7 @@ graph LR
     
     A --> E[Entry Point]
     C --> D
-    D --> F[END]
+    D --> F[DONE]
 ```
 
 **Implementation:**
@@ -141,7 +141,7 @@ graph TB
         A[coordinator] --> B{Decision Logic}
         B -->|continue| C[control_tools]
         B -->|suspend| D[suspend]
-        B -->|end| E[finalizer]
+        B -->|done| E[finalizer]
     end
     
     subgraph "Control Tools Routing"
@@ -162,7 +162,7 @@ graph TB
     end
     
     D --> E
-    E --> O[END]
+    E --> O[DONE]
 ```
 
 **Implementation:**
@@ -180,11 +180,11 @@ def _add_coordinator_routing_edges(self, graph: StateGraph) -> None:
     graph.add_conditional_edges(
         GraphNodeNames.COORDINATOR,
         self._coordinator_routing_logic,
-        {
-            RoutingDecision.CONTINUE: GraphNodeNames.CONTROL_TOOLS,
-            RoutingDecision.END: GraphNodeNames.FINALIZER,
-            RoutingDecision.SUSPEND: GraphNodeNames.SUSPEND,
-        },
+                    {
+                RoutingDecision.CONTINUE: GraphNodeNames.CONTROL_TOOLS,
+                RoutingDecision.DONE: GraphNodeNames.FINALIZER,
+                RoutingDecision.SUSPEND: GraphNodeNames.SUSPEND,
+            },
     )
 
 
@@ -195,7 +195,7 @@ def _add_control_tools_routing_edges(self, graph: StateGraph) -> None:
     for plugin_bundle in self.plugin_manager.plugin_bundles.values():
         route_mapping[plugin_bundle.metadata.name] = f"{plugin_bundle.metadata.name}_agent"
 
-    route_mapping[RoutingDecision.END] = GraphNodeNames.FINALIZER
+            route_mapping[RoutingDecision.DONE] = GraphNodeNames.FINALIZER
 
     graph.add_conditional_edges(GraphNodeNames.CONTROL_TOOLS, self._determine_plugin_route, route_mapping)
 
@@ -351,8 +351,8 @@ def _coordinator_routing_logic(self, state: AgentState) -> str:
         self.logger.debug("Routing to CONTINUE due to tool calls present")
         return RoutingDecision.CONTINUE
     else:
-        self.logger.debug("Routing to END - no tool calls and hop limit not reached")
-        return RoutingDecision.END
+        self.logger.debug("Routing to DONE - no tool calls and agent hop limit not reached")
+        return RoutingDecision.DONE
 ```
 
 ### Enhanced Tool Call Detection
@@ -387,6 +387,35 @@ This enhanced detection provides:
 - Clear visibility into tool call processing
 - Better error diagnosis capabilities
 
+### Coordinator Response Enforcement
+
+The coordinator now enforces proper routing by ensuring all responses go through the finalizer node:
+
+```python
+if is_routing_to_agent:
+    tool_calls = getattr(coordinator_response, "tool_calls", [])
+    if tool_calls:
+        current_agent_hops = self.calculate_agent_hops(current_agent_hops, tool_calls)
+else:
+    # If no tool calls, remove content and add fake tool call to finalizer
+    # This ensures the coordinator always routes through the finalizer node
+    coordinator_response.content = ""
+    # Create a fake tool call to goto_finalize
+    fake_tool_call = ToolCall(
+        id="fake_finalize_call",
+        name="goto_finalize",
+        args={}
+    )
+    coordinator_response.tool_calls = [fake_tool_call]
+```
+
+This fix ensures:
+
+- **Consistent Routing**: All responses go through the finalizer node for proper synthesis
+- **No Direct Answers**: The coordinator never answers questions directly
+- **Proper Flow**: Maintains the intended conversation flow through the finalizer
+- **Content Cleanup**: Removes any direct response content from the coordinator
+
 ### Hop Limit Management
 
 The system prevents infinite loops through hop counting:
@@ -395,13 +424,11 @@ The system prevents infinite loops through hop counting:
 graph LR
     subgraph "Hop Counting"
         A[agent_hops] --> B{Check Limits}
-        C[tool_hops] --> B
         B -->|Exceeded| D[Route to Suspend]
         B -->|Within Limits| E[Continue Processing]
     end
     
     subgraph "State Tracking"
-        F[ToolExecutionLogger] --> G[Increment tool_hops]
         H[Agent Switches] --> I[Increment agent_hops]
         J[Message Filtering] --> K[Safe State Updates]
     end
@@ -613,26 +640,21 @@ flowchart TD
 
 ## Tool Execution Logging and Safety
 
-The system includes a comprehensive `ToolExecutionLogger` callback handler for tracking tool execution and managing hop
+The system includes a comprehensive `ToolExecutionLogger` callback handler for tracking tool execution and managing
+agent hop
 counting:
 
 ```python
 class ToolExecutionLogger(BaseCallbackHandler):
-    """Logs tool execution and manages hop counting for conversation safety."""
+    """Logs tool execution and manages agent hop counting for conversation safety."""
 
     def on_tool_start(self, serialized=None, input_str=None, **kwargs):
-        """Logs tool execution start and updates hop counters for non-routing tools."""
+        """Logs tool execution start for debugging purposes."""
         try:
             tool_name = serialized.get("name") if isinstance(serialized, dict) else None
             self.logger.debug(f"Tool start: name={tool_name or 'unknown'} input={input_str}")
 
-            if tool_name.startswith("goto_"):
-                self.logger.debug(f"Tool name={tool_name or 'unknown'} is skipped from counting")
-            elif self.state_updater:
-                self.logger.debug(f"Updating tool_hops: +1 (tool: {tool_name})")
-                self.state_updater("tool_hops", 1)
-            else:
-                self.logger.warning("No state_updater available for tool_hops tracking")
+
         except Exception as e:
             self.logger.error(f"Error in on_tool_start: {e}")
 
@@ -729,7 +751,7 @@ graph TB
         
         C -->|continue| D[control_tools]
         C -->|suspend| E[suspend]
-        C -->|end| K[Enhanced Finalizer]
+        C -->|done| K[Enhanced Finalizer]
         
         D --> G{Plugin Selection}
         G -->|math| H[math_agent]
@@ -746,12 +768,11 @@ graph TB
         N --> O
         
         E --> K
-        K --> F[END]
+        K --> F[DONE]
     end
     
     subgraph "State Management"
         P[AgentState] --> Q[agent_hops]
-        P --> R[tool_hops]
         P --> S[messages]
         P --> T[current_agent]
         P --> U[tone]
@@ -833,10 +854,10 @@ def _create_state_update(message: AIMessage, agent_hops: int, state: Dict[str, A
         "agent_hops": agent_hops,
     }
 
-    if state:
-        for key in ["tool_hops", "current_agent", "plugin_context", "session_id"]:
-            if key in state:
-                update[key] = state[key]
+            if state:
+            for key in ["current_agent", "plugin_context", "thread_id"]:
+                if key in state:
+                    update[key] = state[key]
 
     return update
 ```
@@ -844,7 +865,7 @@ def _create_state_update(message: AIMessage, agent_hops: int, state: Dict[str, A
 This ensures:
 
 - Consistent state structure across all nodes
-- Proper hop counting and tracking
+- Proper agent hop counting and tracking
 - Preservation of important state fields
 - Clean separation between new and existing state data
 
@@ -926,10 +947,10 @@ sequenceDiagram
 ```mermaid
 graph LR
     subgraph "State Progression"
-        A[agent_hops: 0<br/>tool_hops: 0]
-        B[agent_hops: 1<br/>tool_hops: 1]
-        C[agent_hops: 2<br/>tool_hops: 2]
-        D[agent_hops: 2<br/>tool_hops: 2]
+        A[agent_hops: 0]
+        B[agent_hops: 1]
+        C[agent_hops: 2]
+        D[agent_hops: 2]
     end
     
     A --> B --> C --> D
@@ -1076,7 +1097,6 @@ graph TB
 graph LR
     subgraph "Configuration"
         A[Settings] --> B[Max Agent Hops]
-        A --> C[Max Tool Hops]
         A --> D[Graph Recursion Limit]
         A --> E[LLM Provider Settings]
         A --> F[Separate Model Configs]
@@ -1094,7 +1114,7 @@ graph LR
         M[Coordinator Model] --> N[Parallel Tool Calls]
         O[Suspend Model] --> P[Graceful Termination]
         Q[Finalizer Model] --> R[Tone-Aware Responses]
-        S[ToolExecutionLogger] --> T[Hop Counting]
+        S[ToolExecutionLogger] --> T[Agent Hop Counting]
         U[State Updates] --> V[Standardized Format]
     end
 ```
@@ -1177,13 +1197,13 @@ def _determine_plugin_route(self, state: AgentState) -> str:
     """Route to appropriate plugin agent based on tool results."""
     messages = state.get("messages", [])
     if not messages:
-        return RoutingDecision.END
+        return RoutingDecision.DONE
 
     last_message = messages[-1]
 
     if not self._is_valid_tool_message(last_message):
         self.logger.warning("No valid tool message found in routing")
-        return RoutingDecision.END
+        return RoutingDecision.DONE
 
     tool_result = last_message.content
     self.logger.debug(
@@ -1195,10 +1215,10 @@ def _determine_plugin_route(self, state: AgentState) -> str:
     ]:
         return tool_result
     elif tool_result == "finalize":
-        return RoutingDecision.END
+        return RoutingDecision.DONE
     else:
-        self.logger.warning(f"Unknown tool result: '{tool_result}', routing to END")
-        return RoutingDecision.END
+        self.logger.warning(f"Unknown tool result: '{tool_result}', routing to DONE")
+        return RoutingDecision.DONE
 
 
 @staticmethod

--- a/docs/concepts/plugin-system.md
+++ b/docs/concepts/plugin-system.md
@@ -20,7 +20,7 @@ Cadence plugins are self-contained packages discovered via the SDK registry. Eac
 The coordinator offers `goto_{plugin}` tools generated from plugin metadata plus a `finalize` tool. After agents act:
 
 - `should_continue(state)` returns `continue` to call tools or `back` to return to coordinator
-- Hop limits: `max_agent_hops` and `max_tool_hops` enforce limits; a `suspend` node explains limits to users
+- Hop limits: `max_agent_hops` enforces limits; a `suspend` node explains limits to users
 
 ## Configuration
 

--- a/docs/deployment/environment.md
+++ b/docs/deployment/environment.md
@@ -94,7 +94,6 @@ CADENCE_PLUGINS_DIR=["/abs/path/one", "/abs/path/two"]
 | Variable                        | Default | Description                                                                  |
 |---------------------------------|---------|------------------------------------------------------------------------------|
 | `CADENCE_MAX_AGENT_HOPS`        | `25`    | Maximum agent switches before suspend/finalization                           |
-| `CADENCE_MAX_TOOL_HOPS`         | `50`    | Maximum tool calls per request before suspend/finalization                   |
 | `CADENCE_GRAPH_RECURSION_LIMIT` | `50`    | Maximum LangGraph steps per request (prevents graph recursion/infinite loop) |
 
 ### Conversation Storage Configuration
@@ -237,7 +236,6 @@ CADENCE_MAX_SESSION_HISTORY=50
 
 # Processing Configuration
 CADENCE_MAX_AGENT_HOPS=25
-CADENCE_MAX_TOOL_HOPS=50
 CADENCE_GRAPH_RECURSION_LIMIT=50
 
 # --- Azure OpenAI (alternative) ---
@@ -288,7 +286,6 @@ CADENCE_MAX_SESSION_HISTORY=100
 
 # Processing Configuration
 CADENCE_MAX_AGENT_HOPS=25
-CADENCE_MAX_TOOL_HOPS=50
 CADENCE_GRAPH_RECURSION_LIMIT=50
 
 # --- Azure OpenAI (alternative) ---
@@ -330,7 +327,6 @@ services:
       - CADENCE_PERSISTENCE_MEMORY_LAYER=redis
       - CADENCE_REDIS_URL=redis://redis:6379/0
       - CADENCE_MAX_AGENT_HOPS=25
-      - CADENCE_MAX_TOOL_HOPS=50
       - CADENCE_GRAPH_RECURSION_LIMIT=50
       # Azure OpenAI (alternative)
       # - CADENCE_DEFAULT_LLM_PROVIDER=azure-openai
@@ -454,7 +450,6 @@ data:
   CADENCE_API_PORT: "8000"
   CADENCE_SESSION_TIMEOUT: "3600"
   CADENCE_MAX_AGENT_HOPS: "25"
-  CADENCE_MAX_TOOL_HOPS: "50"
   CADENCE_GRAPH_RECURSION_LIMIT: "50"
   # Conversation Storage
   CADENCE_CONVERSATION_STORAGE_BACKEND: "postgresql"

--- a/docs/deployment/production.md
+++ b/docs/deployment/production.md
@@ -45,7 +45,7 @@ services:
       - CADENCE_REDIS_URL=redis://redis:6379/0
       - CADENCE_SESSION_TIMEOUT=3600
       - CADENCE_MAX_AGENT_HOPS=25
-      - CADENCE_MAX_TOOL_HOPS=50
+
     volumes:
       - ./plugins:/opt/cadence/plugins:ro
       - cadence-logs:/var/log/cadence
@@ -358,7 +358,7 @@ active_connections = Gauge('cadence_active_connections', 'Active connections')
 
 ```python
 # Redis caching configuration
-CADENCE_REDIS_URL = redis://localhost:6379/0
+CADENCE_REDIS_URL = redis: // localhost: 6379 / 0
 CADENCE_CACHE_TTL = 3600
 CADENCE_SESSION_CACHE_TTL = 7200
 ```

--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -180,7 +180,7 @@ PluginMetadata(
         "max_tokens": 1024
     },
     agent_type="specialized",
-    dependencies=["cadence_sdk>=1.0.1,<2.0.0"],
+                dependencies=["cadence_sdk>=1.0.2,<2.0.0"],
 )
 ```
 
@@ -202,16 +202,17 @@ register_plugin(MathPlugin)
 ```python
 from cadence_sdk import BasePlugin, PluginMetadata
 
+
 class MathPlugin(BasePlugin):
     @staticmethod
     def get_metadata() -> PluginMetadata:
         return PluginMetadata(
             name="mathematics",
-            version="1.0.1",
+            version="1.0.2",
             description="Mathematical calculations and arithmetic operations agent",
             agent_type="specialized",
             capabilities=["addition", "subtraction", "multiplication", "division"],
-            dependencies=["cadence_sdk>=1.0.1,<2.0.0"],
+            dependencies=["cadence_sdk>=1.0.2,<2.0.0"],
         )
 
     @staticmethod
@@ -225,6 +226,7 @@ class MathPlugin(BasePlugin):
 ```python
 from cadence_sdk import BaseAgent
 from cadence_sdk.base.metadata import PluginMetadata
+
 
 class MathAgent(BaseAgent):
     def __init__(self, metadata: PluginMetadata):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "cadence"
-version = "1.0.1"
+version = "1.0.2"
 description = "Cadence AI - Multi-agent AI orchestration system with plugin management"
 authors = [
     { name = "Jonas Kahn", email = "me@ifelse.one" }

--- a/src/cadence/api/__init__.py
+++ b/src/cadence/api/__init__.py
@@ -3,7 +3,7 @@
 Provides FastAPI router and service initialization for the multi-agent conversation system.
 """
 
-from .routes import router
 from ..core.services.service_container import initialize_container
+from .routes import router
 
 __all__ = ["router", "initialize_container"]

--- a/src/cadence/api/routers/chat.py
+++ b/src/cadence/api/routers/chat.py
@@ -7,9 +7,9 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends
 
-from ..services import global_service_container
 from ...core.services import ConversationService
 from ...domain.dtos.chat_dtos import ChatRequest, ChatResponse
+from ..services import global_service_container
 
 chat_api_router = APIRouter()
 
@@ -21,8 +21,8 @@ def get_conversation_service() -> ConversationService:
 
 @chat_api_router.post("/chat", response_model=ChatResponse)
 async def process_chat_message(
-        chat_request: ChatRequest,
-        conversation_service: ConversationService = Depends(get_conversation_service),
+    chat_request: ChatRequest,
+    conversation_service: ConversationService = Depends(get_conversation_service),
 ) -> ChatResponse:
     """Process user message through multi-agent orchestrator."""
     return await conversation_service.process_message(chat_request)

--- a/src/cadence/api/routers/plugins.py
+++ b/src/cadence/api/routers/plugins.py
@@ -9,9 +9,9 @@ from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException
 
+from ...infrastructure.plugins.sdk_manager import SDKPluginManager
 from ..schemas import PluginInfo
 from ..services import global_service_container
-from ...infrastructure.plugins.sdk_manager import SDKPluginManager
 
 plugins_api_router = APIRouter()
 
@@ -47,7 +47,7 @@ async def list_available_plugins(plugin_manager: SDKPluginManager = Depends(get_
 
 @plugins_api_router.get("/plugins/{plugin_name}", response_model=PluginInfo)
 async def get_plugin_details(
-        plugin_name: str, plugin_manager: SDKPluginManager = Depends(get_plugin_manager)
+    plugin_name: str, plugin_manager: SDKPluginManager = Depends(get_plugin_manager)
 ) -> PluginInfo:
     """Retrieve detailed metadata and status for specified plugin."""
     plugin_bundle = plugin_manager.get_plugin_bundle(plugin_name)

--- a/src/cadence/api/routers/system.py
+++ b/src/cadence/api/routers/system.py
@@ -7,9 +7,9 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends
 
+from ...infrastructure.plugins.sdk_manager import SDKPluginManager
 from ..schemas import SystemStatus
 from ..services import global_service_container
-from ...infrastructure.plugins.sdk_manager import SDKPluginManager
 
 system_api_router = APIRouter()
 
@@ -21,7 +21,7 @@ def get_plugin_manager() -> SDKPluginManager:
 
 @system_api_router.get("/status", response_model=SystemStatus)
 async def get_comprehensive_system_status(
-        plugin_manager: SDKPluginManager = Depends(get_plugin_manager),
+    plugin_manager: SDKPluginManager = Depends(get_plugin_manager),
 ) -> SystemStatus:
     """Retrieve comprehensive system status and plugin health information."""
     return SystemStatus(

--- a/src/cadence/api/routes.py
+++ b/src/cadence/api/routes.py
@@ -18,13 +18,13 @@ router.include_router(system.router, prefix="/system", tags=["system"])
 @router.get("/")
 async def root():
     """API root endpoint with service information."""
-    return {"message": "Welcome to Cadence AI Framework API", "version": "1.0.1", "docs": "/docs", "health": "/health"}
+    return {"message": "Welcome to Cadence AI Framework API", "version": "1.0.2", "docs": "/docs", "health": "/health"}
 
 
 @router.get("/health")
 async def health_check():
     """Service health check for monitoring systems."""
-    return {"status": "healthy", "service": "cadence-api", "version": "1.0.1"}
+    return {"status": "healthy", "service": "cadence-api", "version": "1.0.2"}
 
 
 async def initialize_api(settings: Settings) -> None:

--- a/src/cadence/api/schemas.py
+++ b/src/cadence/api/schemas.py
@@ -16,7 +16,7 @@ class ChatRequest(BaseModel):
     message: str = Field(
         ..., description="User message to be processed by the multi-agent system", min_length=1, max_length=10000
     )
-    session_id: Optional[str] = Field(
+    thread_id: Optional[str] = Field(
         default=None, description="Optional session identifier for conversation threading", max_length=255
     )
     metadata: Optional[Dict[str, Any]] = Field(
@@ -33,7 +33,7 @@ class ChatResponse(BaseModel):
     """Agent response with session information."""
 
     response: str = Field(..., description="Agent's response to the user message")
-    session_id: str = Field(..., description="Session identifier for conversation threading")
+    thread_id: str = Field(..., description="Session identifier for conversation threading")
     metadata: Optional[Dict[str, Any]] = Field(
         default=None, description="Optional processing metadata (agent, tokens, timing)"
     )

--- a/src/cadence/cli.py
+++ b/src/cadence/cli.py
@@ -21,7 +21,7 @@ console = Console()
 
 
 @click.group()
-@click.version_option(version="1.0.1", prog_name="cadence")
+@click.version_option(version="1.0.2", prog_name="cadence")
 @click.option("--debug", is_flag=True, help="Enable debug mode")
 @click.option("--config", type=click.Path(exists=True), help="Path to configuration file")
 @click.pass_context
@@ -297,7 +297,6 @@ def config(ctx):
         table.add_row("LLM Provider", settings.default_llm_provider, "Default LLM provider")
         table.add_row("Storage Backend", settings.conversation_storage_backend, "Conversation storage")
         table.add_row("Max Agent Hops", str(settings.max_agent_hops), "Maximum agent switches")
-        table.add_row("Max Tool Hops", str(settings.max_tool_hops), "Maximum tool calls")
 
         console.print(table)
 

--- a/src/cadence/config/settings.py
+++ b/src/cadence/config/settings.py
@@ -66,7 +66,6 @@ class Settings(BaseSettings):
     # Conversation settings
     conversation_storage_backend: str = Field(default="memory", description="Conversation storage backend")
     max_agent_hops: int = Field(default=25, description="Maximum agent hops per conversation")
-    max_tool_hops: int = Field(default=50, description="Maximum tool calls per agent")
     graph_recursion_limit: int = Field(default=50, description="Maximum graph recursion depth")
 
     # Session settings

--- a/src/cadence/core/orchestrator/coordinator.py
+++ b/src/cadence/core/orchestrator/coordinator.py
@@ -5,14 +5,15 @@ and infinite loop prevention through hop counters.
 """
 
 import traceback
+import uuid
 from enum import Enum
 from typing import Any, Dict, List
 
 from cadence_sdk.base.loggable import Loggable
 from cadence_sdk.types import AgentState
 from langchain_core.callbacks.base import BaseCallbackHandler
-from langchain_core.messages import AIMessage, SystemMessage
-from langgraph.graph import StateGraph
+from langchain_core.messages import AIMessage, SystemMessage, ToolCall
+from langgraph.graph import END, StateGraph
 from langgraph.prebuilt import ToolNode
 
 from ...config.settings import Settings
@@ -64,19 +65,23 @@ class RoutingDecision:
 
     CONTINUE = "continue"
     SUSPEND = "suspend"
-    END = "end"
+    DONE = "done"
     FINAL = "final"
 
 
 class ConversationPrompts:
     """System prompts for different conversation roles."""
 
-    COORDINATOR_INSTRUCTIONS = """Your goal is to analyze queries and decide which agent to route to from the **AVAILABLE AGENTS**.
+    COORDINATOR_INSTRUCTIONS = """You are Coordinator Node in Multiple Agents System. 
+Your goal is to analyze current user query base on whole context chat histories and decide next step by route to an agent from the **AVAILABLE AGENTS**. 
 **AVAILABLE AGENTS**
 {plugin_descriptions}
-- finalize: Call when you think the answer for the user query/question is ready, simple greeting questions, etc, and no suitable agents.
+- finalize: Call when you think the answer for the user query/question is ready, simple questions: like greeting, etc, and no suitable agents.
+**IMPORTANT**
+- Avoid rework if information existed in chat histories
+- Your role is select next step, only for this purpose
 **DECISION OUTPUT**
-- Choose ONE of: {tool_options} | goto_finalize"""
+- Choose ONLY ONE for the next step: {tool_options} | goto_finalize"""
 
     HOP_LIMIT_REACHED = """You have reached maximum agent call ({current}/{maximum}) allowed by the system.
 **What this means:**
@@ -91,40 +96,34 @@ class ConversationPrompts:
 4. If the answer is incomplete, explain why and suggest the user continue the chat
 
 **IMPORTANT**, never makeup the answer if provided information by agents not enough
+**RESPONSE STYLE**: {tone_instruction}
+**LANGUAGE**: Respond in the same language as the user's query or as explicitly requested by the user.
 Please provide a helpful response that addresses the user's query while explaining the hop limit situation."""
 
     FINALIZER_INSTRUCTIONS = """You are the Finalizer, responsible for creating the final response for a multi-agent conversation.
-
 CRITICAL REQUIREMENTS:
 1. **RESPECT AGENT RESPONSES** - Use ONLY the information provided by agents and tools, do NOT make up or add information
 2. **ADDRESS CURRENT USER QUERY** - Focus on answering the recent user question, use previous conversation as context
-3. **SYNTHESIZE RELEVANT WORK** - Connect and organize the work done by different agents into a coherent answer
+3. **SYNTHESIZE RELEVANT WORK** - Connect and organize the work done by work done in each step for answer
 4. **BE HELPFUL** - Provide useful, actionable information that directly answers the user's question
 5. **RESPONSE STYLE**: {tone_instruction}
+6. **LANGUAGE**: Respond in the same language as the user's query or as explicitly requested by the user.
 
 IMPORTANT: Your role is to synthesize and present the information that agents have gathered, not to generate new information or make assumptions beyond what's provided in the conversation."""
 
 
 class ToolExecutionLogger(BaseCallbackHandler):
-    """Logs tool execution and manages hop counting for conversation safety."""
+    """Logs tool execution for conversation tracking."""
 
     def __init__(self, logger, state_updater=None):
         self.logger = logger
         self.state_updater = state_updater
 
     def on_tool_start(self, serialized=None, input_str=None, **kwargs):
-        """Log tool execution start and update hop counters for non-routing tools."""
+        """Log tool execution start."""
         try:
             tool_name = serialized.get("name") if isinstance(serialized, dict) else None
             self.logger.debug(f"Tool start: name={tool_name or 'unknown'} input={input_str}")
-
-            if tool_name.startswith("goto_"):
-                self.logger.debug(f"Tool name={tool_name or 'unknown'} is skipped from counting")
-            elif self.state_updater:
-                self.logger.debug(f"Updating tool_hops: +1 (tool: {tool_name})")
-                self.state_updater("tool_hops", 1)
-            else:
-                self.logger.warning("No state_updater available for tool_hops tracking")
         except Exception as e:
             self.logger.error(f"Error in on_tool_start: {e}")
 
@@ -141,11 +140,11 @@ class MultiAgentOrchestrator(Loggable):
     """Coordinates multi-agent conversations using LangGraph with dynamic plugin integration."""
 
     def __init__(
-            self,
-            plugin_manager: SDKPluginManager,
-            llm_factory: LLMModelFactory,
-            settings: Settings,
-            checkpointer: Any | None = None,
+        self,
+        plugin_manager: SDKPluginManager,
+        llm_factory: LLMModelFactory,
+        settings: Settings,
+        checkpointer: Any | None=None,
     ) -> None:
         super().__init__()
         self.plugin_manager = plugin_manager
@@ -178,7 +177,7 @@ class MultiAgentOrchestrator(Loggable):
         )
 
         base_model = self.llm_factory.create_base_model(model_config)
-        return base_model.bind_tools(control_tools, parallel_tool_calls=True)
+        return base_model.bind_tools(control_tools, parallel_tool_calls=False)
 
     def _create_suspend_model(self):
         """Create LLM model for suspend node with fallback to default."""
@@ -282,10 +281,12 @@ class MultiAgentOrchestrator(Loggable):
             self._coordinator_routing_logic,
             {
                 RoutingDecision.CONTINUE: GraphNodeNames.CONTROL_TOOLS,
-                RoutingDecision.END: GraphNodeNames.FINALIZER,
+                RoutingDecision.DONE: GraphNodeNames.FINALIZER,
                 RoutingDecision.SUSPEND: GraphNodeNames.SUSPEND,
             },
         )
+        graph.add_edge(GraphNodeNames.SUSPEND, END)
+        graph.add_edge(GraphNodeNames.FINALIZER, END)
 
     def _add_control_tools_routing_edges(self, graph: StateGraph) -> None:
         """Add conditional edges from control tools to plugin agents and finalizer."""
@@ -294,7 +295,7 @@ class MultiAgentOrchestrator(Loggable):
         for plugin_bundle in self.plugin_manager.plugin_bundles.values():
             route_mapping[plugin_bundle.metadata.name] = f"{plugin_bundle.metadata.name}_agent"
 
-        route_mapping[RoutingDecision.END] = GraphNodeNames.FINALIZER
+        route_mapping[RoutingDecision.DONE] = GraphNodeNames.FINALIZER
 
         graph.add_conditional_edges(GraphNodeNames.CONTROL_TOOLS, self._determine_plugin_route, route_mapping)
 
@@ -315,8 +316,8 @@ class MultiAgentOrchestrator(Loggable):
             self.logger.debug("Routing to CONTINUE due to tool calls present")
             return RoutingDecision.CONTINUE
         else:
-            self.logger.debug("Routing to END - no tool calls and hop limit not reached")
-            return RoutingDecision.END
+            self.logger.debug("Routing to DONE - no tool calls and hop limit not reached")
+            return RoutingDecision.DONE
 
     def _is_hop_limit_reached(self, state: AgentState) -> bool:
         """Check if conversation has reached maximum allowed agent hops."""
@@ -347,13 +348,13 @@ class MultiAgentOrchestrator(Loggable):
         """Route to appropriate plugin agent based on tool results."""
         messages = state.get("messages", [])
         if not messages:
-            return RoutingDecision.END
+            return RoutingDecision.DONE
 
         last_message = messages[-1]
 
         if not self._is_valid_tool_message(last_message):
             self.logger.warning("No valid tool message found in routing")
-            return RoutingDecision.END
+            return RoutingDecision.DONE
 
         tool_result = last_message.content
         self.logger.debug(
@@ -365,10 +366,10 @@ class MultiAgentOrchestrator(Loggable):
         ]:
             return tool_result
         elif tool_result == "finalize":
-            return RoutingDecision.END
+            return RoutingDecision.DONE
         else:
-            self.logger.warning(f"Unknown tool result: '{tool_result}', routing to END")
-            return RoutingDecision.END
+            self.logger.warning(f"Unknown tool result: '{tool_result}', routing to DONE")
+            return RoutingDecision.DONE
 
     @staticmethod
     def _is_valid_tool_message(message: Any) -> bool:
@@ -386,9 +387,7 @@ class MultiAgentOrchestrator(Loggable):
         )
 
         system_message = SystemMessage(content=coordinator_prompt)
-        safe_messages = self._filter_safe_messages(messages)
-
-        coordinator_response = self.coordinator_model.invoke([system_message] + safe_messages)
+        coordinator_response = self.coordinator_model.invoke([system_message] + messages)
 
         current_agent_hops = state.get("agent_hops", 0)
         is_routing_to_agent = self._has_tool_calls({"messages": [coordinator_response]})
@@ -396,22 +395,36 @@ class MultiAgentOrchestrator(Loggable):
         if is_routing_to_agent:
             tool_calls = getattr(coordinator_response, "tool_calls", [])
             if tool_calls:
-                first_tool_name = (
-                    tool_calls[0].get("name") if isinstance(tool_calls[0], dict) else getattr(tool_calls[0], "name", "")
-                )
-                is_not_finalize_call = first_tool_name and first_tool_name != "goto_finalize"
-                if is_not_finalize_call:
-                    current_agent_hops += 1
-
+                current_agent_hops = self.calculate_agent_hops(current_agent_hops, tool_calls)
+        else:
+            coordinator_response.content = ""
+            coordinator_response.tool_calls = [ ToolCall(
+                id=str(uuid.uuid4()),
+                name="goto_finalize",
+                args={}
+            )]
+            
         return self._create_state_update(coordinator_response, current_agent_hops, state)
+
+    @staticmethod
+    def calculate_agent_hops(current_agent_hops, tool_calls):
+        potential_tool_calls = list(map(lambda x: x.get("name"), tool_calls))
+        for potential_tool_call in potential_tool_calls:
+            if potential_tool_call != "goto_finalize":
+                current_agent_hops += 1
+        return current_agent_hops
 
     def _suspend_node(self, state: AgentState) -> AgentState:
         """Handle graceful conversation termination when hop limits are exceeded."""
         current_hops = state.get("agent_hops", 0)
         max_hops = self.settings.max_agent_hops
+        requested_tone = state.get("tone", "natural") or "natural"
+        tone_instruction = self._get_tone_instruction(requested_tone)
 
         suspension_message = SystemMessage(
-            content=ConversationPrompts.HOP_LIMIT_REACHED.format(current=current_hops, maximum=max_hops)
+            content=ConversationPrompts.HOP_LIMIT_REACHED.format(
+                current=current_hops, maximum=max_hops, tone_instruction=tone_instruction
+            )
         )
 
         safe_messages = self._filter_safe_messages(state["messages"])
@@ -428,9 +441,7 @@ class MultiAgentOrchestrator(Loggable):
             tone_instruction=tone_instruction
         )
         finalization_prompt = SystemMessage(content=finalization_prompt_content)
-
-        safe_messages = self._filter_safe_messages(messages)
-        final_response = self.finalizer_model.invoke([finalization_prompt] + safe_messages)
+        final_response = self.finalizer_model.invoke([finalization_prompt] + messages)
 
         return self._create_state_update(final_response, state.get("agent_hops", 0), state)
 
@@ -439,15 +450,11 @@ class MultiAgentOrchestrator(Loggable):
         """Return appropriate tone instruction based on requested response style."""
         return ResponseTone.get_description(tone)
 
-    def _update_tool_hops(self, field: str, increment: int) -> None:
-        """Update tool hops counter for tool execution logger."""
-        self.logger.debug(f"Tool execution logger requested update: {field} += {increment}")
-
     def _build_plugin_descriptions(self) -> str:
         """Build formatted string of available plugin descriptions."""
         descriptions = []
         for plugin_bundle in self.plugin_manager.plugin_bundles.values():
-            descriptions.append(f"- {plugin_bundle.metadata.name}: {plugin_bundle.metadata.description}")
+            descriptions.append(f"- **{plugin_bundle.metadata.name}**: {plugin_bundle.metadata.description}")
         return "\n".join(descriptions)
 
     def _build_tool_options(self) -> str:
@@ -457,48 +464,20 @@ class MultiAgentOrchestrator(Loggable):
         ]
         return " | ".join(tool_names)
 
-    def _invoke_model_with_prompt(self, system_prompt: SystemMessage, messages: List) -> AIMessage:
-        """Invoke coordinator model with system prompt and conversation messages."""
-        safe_messages = self._filter_safe_messages(messages)
-        return self.coordinator_model.invoke([system_prompt] + safe_messages)
-
-    def _filter_safe_messages(self, messages: List) -> List:
+    @staticmethod
+    def _filter_safe_messages(messages: List) -> List:
         """Remove messages with incomplete tool call sequences to prevent validation errors."""
         if not messages:
             return []
-
-        filtered_messages = []
-        for message_index, message in enumerate(messages):
-            if self._is_incomplete_tool_call_sequence(message, messages, message_index):
-                self.logger.warning(f"Skipping incomplete tool call sequence in message {message_index}")
-                continue
-            filtered_messages.append(message)
-
-        return filtered_messages
-
-    def _is_incomplete_tool_call_sequence(self, message: Any, messages: List, message_index: int) -> bool:
-        """Determine if assistant message contains tool calls without proper responses."""
-        if not (hasattr(message, "tool_calls") and message.tool_calls and isinstance(message, AIMessage)):
-            return False
-
-        tool_call_ids = {tc.get("id") for tc in message.tool_calls if tc.get("id")}
-        found_tool_responses = self._find_tool_responses(messages, message_index)
-
-        return not tool_call_ids.issubset(found_tool_responses)
-
-    def _find_tool_responses(self, messages: List, message_index: int) -> set:
-        """Search for tool response messages that correspond to tool calls."""
-        found_tool_responses = set()
-        look_ahead_limit = min(message_index + 10, len(messages))
-
-        for next_message in messages[message_index + 1: look_ahead_limit]:
-            if hasattr(next_message, "tool_call_id") and next_message.tool_call_id:
-                found_tool_responses.add(next_message.tool_call_id)
-
-        return found_tool_responses
+        last_message = messages[-1]
+        if isinstance(last_message, AIMessage):
+            messages.pop()
+            return messages
+        else:
+            return messages
 
     @staticmethod
-    def _create_state_update(message: AIMessage, agent_hops: int, state: Dict[str, Any] = None) -> Dict[str, Any]:
+    def _create_state_update(message: AIMessage, agent_hops: int, state: Dict[str, Any]=None) -> Dict[str, Any]:
         """Create standardized state update structure for graph node responses."""
         update = {
             "messages": [message],
@@ -506,7 +485,7 @@ class MultiAgentOrchestrator(Loggable):
         }
 
         if state:
-            for key in ["tool_hops", "current_agent", "plugin_context", "session_id"]:
+            for key in ["current_agent", "plugin_context", "thread_id"]:
                 if key in state:
                     update[key] = state[key]
 

--- a/src/cadence/core/services/conversation_service.py
+++ b/src/cadence/core/services/conversation_service.py
@@ -9,11 +9,11 @@ from typing import Any, Dict, List, Optional
 
 from cadence_sdk.base.loggable import Loggable
 
-from ..orchestrator.coordinator import MultiAgentOrchestrator
 from ...domain.dtos.chat_dtos import ChatRequest, ChatResponse, TokenUsage
 from ...domain.models.conversation import Conversation
 from ...domain.models.thread import Thread, ThreadStatus
 from ...infrastructure.database.repositories import ConversationRepository, ThreadRepository
+from ..orchestrator.coordinator import MultiAgentOrchestrator
 
 
 class ConversationService(Loggable):
@@ -24,10 +24,10 @@ class ConversationService(Loggable):
     """
 
     def __init__(
-            self,
-            thread_repository: ThreadRepository,
-            conversation_repository: ConversationRepository,
-            orchestrator: MultiAgentOrchestrator,
+        self,
+        thread_repository: ThreadRepository,
+        conversation_repository: ConversationRepository,
+        orchestrator: MultiAgentOrchestrator,
     ):
         super().__init__()
         self.thread_repository = thread_repository
@@ -60,13 +60,13 @@ class ConversationService(Loggable):
         return thread
 
     async def _process_message_internal(
-            self,
-            thread: Thread,
-            message: str,
-            user_id: str,
-            org_id: str,
-            metadata: Optional[Dict[str, Any]] = None,
-            tone: Optional[str] = None,
+        self,
+        thread: Thread,
+        message: str,
+        user_id: str,
+        org_id: str,
+        metadata: Optional[Dict[str, Any]] = None,
+        tone: Optional[str] = None,
     ) -> ChatResponse:
         """Process message through orchestrator and store optimized conversation data."""
         conversation_history = await self.conversation_repository.get_conversation_history(thread.thread_id, limit=50)
@@ -78,10 +78,8 @@ class ConversationService(Loggable):
             "messages": langgraph_context,
             "current_agent": "coordinator",
             "agent_hops": 0,
-            "tool_hops": 0,
-            "session_id": thread.thread_id,
+            "thread_id": thread.thread_id,
             "plugin_context": {},
-            "agents_used": [],
             "metadata": {
                 "thread_id": thread.thread_id,
                 "user_id": user_id,
@@ -109,7 +107,6 @@ class ConversationService(Loggable):
             assistant_tokens=assistant_token_count,
             metadata={
                 "agent_hops": processing_metadata.get("agent_hops", 0),
-                "tool_hops": processing_metadata.get("tool_hops", 0),
                 "processing_time": processing_metadata.get("processing_time"),
                 "tools_used": processing_metadata.get("tools_used", []),
                 "routing_history": processing_metadata.get("routing_history", []),
@@ -133,7 +130,6 @@ class ConversationService(Loggable):
             ),
             metadata={
                 "agent_hops": processing_metadata.get("agent_hops", 0),
-                "tool_hops": processing_metadata.get("tool_hops", 0),
                 "multi_agent": len(set(processing_metadata.get("routing_history", []))) > 1,
                 "tools_used": processing_metadata.get("tools_used", []),
                 "processing_time": processing_metadata.get("processing_time"),
@@ -207,12 +203,10 @@ class ConversationService(Loggable):
         agent_tools = [tool for tool in tools_used if not tool.startswith("goto_")]
         routing_tools = [tool for tool in tools_used if tool.startswith("goto_") and tool != "goto_finalize"]
 
-        tool_hops = len(agent_tools)
         agent_hops = len(routing_tools)
 
         return {
             "tools_used": tools_used,
-            "tool_hops": tool_hops,
             "agent_hops": agent_hops,
             "routing_history": orchestrator_result.get("plugin_context", {}).get("routing_history", []),
             "processing_time": None,
@@ -267,7 +261,7 @@ class ConversationService(Loggable):
         return await self.thread_repository.archive_thread(thread_id)
 
     async def get_user_threads(
-            self, user_id: str, org_id: str, status: Optional[ThreadStatus] = None, limit: int = 20, offset: int = 0
+        self, user_id: str, org_id: str, status: Optional[ThreadStatus] = None, limit: int = 20, offset: int = 0
     ) -> List[Thread]:
         """Get threads for a specific user.
 
@@ -286,7 +280,7 @@ class ConversationService(Loggable):
         )
 
     async def search_conversations(
-            self, query: str, user_id: Optional[str] = None, thread_id: Optional[str] = None, limit: int = 20
+        self, query: str, user_id: Optional[str] = None, thread_id: Optional[str] = None, limit: int = 20
     ) -> List[Conversation]:
         """Search conversation content.
 
@@ -304,11 +298,11 @@ class ConversationService(Loggable):
         )
 
     async def get_conversation_statistics(
-            self,
-            user_id: Optional[str] = None,
-            org_id: Optional[str] = None,
-            start_date: Optional[datetime] = None,
-            end_date: Optional[datetime] = None,
+        self,
+        user_id: Optional[str] = None,
+        org_id: Optional[str] = None,
+        start_date: Optional[datetime] = None,
+        end_date: Optional[datetime] = None,
     ) -> Dict[str, Any]:
         """Get conversation statistics.
 

--- a/src/cadence/core/services/orchestrator_service.py
+++ b/src/cadence/core/services/orchestrator_service.py
@@ -11,8 +11,8 @@ from typing import Any, Dict, List, Optional
 from cadence_sdk.types.state import AgentState
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
 
-from ..orchestrator.coordinator import MultiAgentOrchestrator
 from ...domain.models.conversation import Conversation
+from ..orchestrator.coordinator import MultiAgentOrchestrator
 
 logger = logging.getLogger(__name__)
 
@@ -25,22 +25,20 @@ class OrchestratorResponse:
     """
 
     def __init__(
-            self,
-            response: str,
-            input_tokens: int,
-            output_tokens: int,
-            agent_hops: int = 0,
-            tool_hops: int = 0,
-            processing_time: float = 0.0,
-            tools_used: Optional[List[str]] = None,
-            routing_history: Optional[List[str]] = None,
-            error: Optional[str] = None,
+        self,
+        response: str,
+        input_tokens: int,
+        output_tokens: int,
+        agent_hops: int = 0,
+        processing_time: float = 0.0,
+        tools_used: Optional[List[str]] = None,
+        routing_history: Optional[List[str]] = None,
+        error: Optional[str] = None,
     ):
         self.response = response
         self.input_tokens = input_tokens
         self.output_tokens = output_tokens
         self.agent_hops = agent_hops
-        self.tool_hops = tool_hops
         self.processing_time = processing_time
         self.tools_used = tools_used or []
         self.routing_history = routing_history or []
@@ -59,7 +57,6 @@ class OrchestratorResponse:
             "output_tokens": self.output_tokens,
             "total_tokens": self.total_tokens,
             "agent_hops": self.agent_hops,
-            "tool_hops": self.tool_hops,
             "processing_time": self.processing_time,
             "tools_used": self.tools_used,
             "routing_history": self.routing_history,
@@ -78,13 +75,13 @@ class OrchestratorService:
         self.orchestrator = orchestrator
 
     async def process_with_context(
-            self,
-            thread_id: str,
-            message: str,
-            conversation_history: List[Conversation],
-            user_id: str = "anonymous",
-            org_id: str = "public",
-            metadata: Optional[Dict[str, Any]] = None,
+        self,
+        thread_id: str,
+        message: str,
+        conversation_history: List[Conversation],
+        user_id: str = "anonymous",
+        org_id: str = "public",
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> OrchestratorResponse:
         """Process message with conversation context."""
         start_time = time.time()
@@ -95,8 +92,7 @@ class OrchestratorService:
             state: AgentState = {
                 "messages": langgraph_context,
                 "agent_hops": 0,
-                "tool_hops": 0,
-                "session_id": thread_id,
+                "thread_id": thread_id,
                 "plugin_context": {},
                 "configurable": {
                     "thread_id": thread_id,
@@ -127,7 +123,6 @@ class OrchestratorService:
                 input_tokens=input_tokens,
                 output_tokens=output_tokens,
                 agent_hops=result.get("agent_hops", 0),
-                tool_hops=result.get("tool_hops", 0),
                 processing_time=processing_time,
                 tools_used=tools_used,
                 routing_history=routing_history,
@@ -201,7 +196,7 @@ class OrchestratorService:
         return max(1, len(text) // 4)
 
     async def process_simple_message(
-            self, message: str, thread_id: str = "temp_session", user_id: str = "anonymous", org_id: str = "public"
+        self, message: str, thread_id: str = "temp_session", user_id: str = "anonymous", org_id: str = "public"
     ) -> OrchestratorResponse:
         """Process a simple message without conversation history.
 
@@ -223,7 +218,6 @@ class OrchestratorService:
                 "healthy_plugins": list(self.orchestrator.plugin_manager.healthy_plugins),
                 "failed_plugins": list(self.orchestrator.plugin_manager.failed_plugins),
                 "max_agent_hops": self.orchestrator.settings.max_agent_hops,
-                "max_tool_hops": self.orchestrator.settings.max_tool_hops,
                 "graph_recursion_limit": self.orchestrator.settings.graph_recursion_limit,
             }
         except Exception as e:

--- a/src/cadence/core/services/service_container.py
+++ b/src/cadence/core/services/service_container.py
@@ -10,9 +10,6 @@ from typing import Optional
 from cadence_sdk.base.loggable import Loggable
 from fastapi import HTTPException
 
-from .conversation_service import ConversationService
-from .orchestrator_service import OrchestratorService
-from ..orchestrator.coordinator import MultiAgentOrchestrator
 from ...config.settings import Settings
 from ...infrastructure.database.factory import DatabaseFactory
 from ...infrastructure.database.repositories import (
@@ -23,6 +20,9 @@ from ...infrastructure.database.repositories import (
 )
 from ...infrastructure.llm.factory import LLMModelFactory
 from ...infrastructure.plugins.sdk_manager import SDKPluginManager
+from ..orchestrator.coordinator import MultiAgentOrchestrator
+from .conversation_service import ConversationService
+from .orchestrator_service import OrchestratorService
 
 logger = logging.getLogger(__name__)
 
@@ -53,10 +53,10 @@ class ServiceContainer(Loggable):
         self.conversation_service: Optional[ConversationService] = None
 
     async def initialize(
-            self,
-            settings: Settings,
-            thread_repository: Optional[ThreadRepository] = None,
-            conversation_repository: Optional[ConversationRepository] = None,
+        self,
+        settings: Settings,
+        thread_repository: Optional[ThreadRepository] = None,
+        conversation_repository: Optional[ConversationRepository] = None,
     ) -> None:
         """Initialize all services with dependency injection."""
         self.logger.info("Initializing enhanced service container...")
@@ -92,8 +92,7 @@ class ServiceContainer(Loggable):
         self.logger.debug(f"Infrastructure initialized with {len(self.plugin_manager.get_available_plugins())} plugins")
 
     async def _initialize_repositories(
-            self, thread_repository: Optional[ThreadRepository],
-            conversation_repository: Optional[ConversationRepository]
+        self, thread_repository: Optional[ThreadRepository], conversation_repository: Optional[ConversationRepository]
     ) -> None:
         """Initialize repositories with dependency injection (backend-aware)."""
         if thread_repository and conversation_repository:
@@ -314,9 +313,9 @@ global_service_container = ServiceContainer()
 
 
 async def initialize_container(
-        settings: Settings,
-        thread_repository: Optional[ThreadRepository] = None,
-        conversation_repository: Optional[ConversationRepository] = None,
+    settings: Settings,
+    thread_repository: Optional[ThreadRepository] = None,
+    conversation_repository: Optional[ConversationRepository] = None,
 ) -> None:
     """Initialize API with enhanced service container.
 

--- a/src/cadence/domain/models/organization.py
+++ b/src/cadence/domain/models/organization.py
@@ -14,15 +14,15 @@ class Organization(BaseModel):
     """
 
     def __init__(
-            self,
-            org_id: str,
-            name: str,
-            created_at: Optional[datetime] = None,
-            is_active: bool = True,
-            settings: Optional[Dict[str, Any]] = None,
-            total_tokens_used: int = 0,
-            monthly_token_limit: Optional[int] = None,
-            **data: Any,
+        self,
+        org_id: str,
+        name: str,
+        created_at: Optional[datetime] = None,
+        is_active: bool = True,
+        settings: Optional[Dict[str, Any]] = None,
+        total_tokens_used: int = 0,
+        monthly_token_limit: Optional[int] = None,
+        **data: Any,
     ):
         super().__init__(**data)
         if not org_id.strip():

--- a/src/cadence/domain/models/thread.py
+++ b/src/cadence/domain/models/thread.py
@@ -21,17 +21,17 @@ class Thread:
     """
 
     def __init__(
-            self,
-            thread_id: Optional[str] = None,
-            user_id: str = "anonymous",
-            org_id: str = "public",
-            created_at: Optional[datetime] = None,
-            updated_at: Optional[datetime] = None,
-            total_tokens: int = 0,
-            input_tokens: int = 0,
-            output_tokens: int = 0,
-            message_count: int = 0,
-            status: ThreadStatus = ThreadStatus.ACTIVE,
+        self,
+        thread_id: Optional[str] = None,
+        user_id: str = "anonymous",
+        org_id: str = "public",
+        created_at: Optional[datetime] = None,
+        updated_at: Optional[datetime] = None,
+        total_tokens: int = 0,
+        input_tokens: int = 0,
+        output_tokens: int = 0,
+        message_count: int = 0,
+        status: ThreadStatus = ThreadStatus.ACTIVE,
     ):
         self.thread_id = thread_id or str(uuid.uuid4())
         self.user_id = user_id

--- a/src/cadence/domain/models/user.py
+++ b/src/cadence/domain/models/user.py
@@ -10,14 +10,14 @@ class User(BaseModel):
     """User entity with identity, lifecycle, and activity tracking."""
 
     def __init__(
-            self,
-            user_id: str,
-            org_id: str = "public",
-            display_name: Optional[str] = None,
-            created_at: Optional[datetime] = None,
-            last_active: Optional[datetime] = None,
-            is_active: bool = True,
-            **data: Any,
+        self,
+        user_id: str,
+        org_id: str = "public",
+        display_name: Optional[str] = None,
+        created_at: Optional[datetime] = None,
+        last_active: Optional[datetime] = None,
+        is_active: bool = True,
+        **data: Any,
     ):
         super().__init__(**data)
         if not user_id.strip():

--- a/src/cadence/infrastructure/database/factory.py
+++ b/src/cadence/infrastructure/database/factory.py
@@ -7,6 +7,7 @@ based on configuration, providing backend-agnostic access to storage.
 import logging
 from typing import Any, Dict, Tuple
 
+from ...config.settings import Settings
 from .connection import DatabaseConnectionManager, initialize_databases
 from .repositories import (
     ConversationRepository,
@@ -18,7 +19,6 @@ from .repositories import (
     RedisThreadRepository,
     ThreadRepository,
 )
-from ...config.settings import Settings
 
 logger = logging.getLogger(__name__)
 

--- a/src/cadence/infrastructure/database/models/conversation.py
+++ b/src/cadence/infrastructure/database/models/conversation.py
@@ -78,8 +78,8 @@ class ConversationModel(Base, TimestampMixin):
     def get_storage_size_estimate(self) -> int:
         """Estimate storage size in bytes for this conversation."""
         return (
-                len(self.user_message.encode("utf-8"))
-                + len(self.assistant_message.encode("utf-8"))
-                + len(str(self.conversation_metadata).encode("utf-8"))
-                + 100
+            len(self.user_message.encode("utf-8"))
+            + len(self.assistant_message.encode("utf-8"))
+            + len(str(self.conversation_metadata).encode("utf-8"))
+            + 100
         )

--- a/src/cadence/infrastructure/database/models/thread.py
+++ b/src/cadence/infrastructure/database/models/thread.py
@@ -3,8 +3,8 @@
 from sqlalchemy import BigInteger, Column, Enum, ForeignKey, Index, Integer, String
 from sqlalchemy.orm import relationship
 
-from .base import Base, TimestampMixin
 from ....domain.models.thread import ThreadStatus
+from .base import Base, TimestampMixin
 
 
 class ThreadModel(Base, TimestampMixin):

--- a/src/cadence/infrastructure/database/repositories/cassandra/cassandra_repositories.py
+++ b/src/cadence/infrastructure/database/repositories/cassandra/cassandra_repositories.py
@@ -53,20 +53,20 @@ class CassandraThreadRepository(ThreadRepository):
         raise NotImplementedError("Cassandra repositories not yet implemented")
 
     async def list_threads(
-            self,
-            user_id: Optional[str] = None,
-            org_id: Optional[str] = None,
-            status: Optional[ThreadStatus] = None,
-            limit: int = 20,
-            offset: int = 0,
-            sort_by: str = "updated_at",
-            sort_order: str = "desc",
+        self,
+        user_id: Optional[str] = None,
+        org_id: Optional[str] = None,
+        status: Optional[ThreadStatus] = None,
+        limit: int = 20,
+        offset: int = 0,
+        sort_by: str = "updated_at",
+        sort_order: str = "desc",
     ) -> List[Thread]:
         """List threads with filtering and pagination."""
         raise NotImplementedError("Cassandra repositories not yet implemented")
 
     async def count_threads(
-            self, user_id: Optional[str] = None, org_id: Optional[str] = None, status: Optional[ThreadStatus] = None
+        self, user_id: Optional[str] = None, org_id: Optional[str] = None, status: Optional[ThreadStatus] = None
     ) -> int:
         """Count threads matching filters."""
         raise NotImplementedError("Cassandra repositories not yet implemented")
@@ -105,7 +105,7 @@ class CassandraConversationRepository(ConversationRepository):
         raise NotImplementedError("Cassandra repositories not yet implemented")
 
     async def get_conversation_history(
-            self, thread_id: str, limit: int = 50, before_id: Optional[str] = None
+        self, thread_id: str, limit: int = 50, before_id: Optional[str] = None
     ) -> List[Conversation]:
         """Get conversation history for a thread, ordered by creation time."""
         raise NotImplementedError("Cassandra repositories not yet implemented")
@@ -115,24 +115,24 @@ class CassandraConversationRepository(ConversationRepository):
         raise NotImplementedError("Cassandra repositories not yet implemented")
 
     async def get_recent_conversations(
-            self, user_id: Optional[str] = None, org_id: Optional[str] = None, limit: int = 10, hours_back: int = 24
+        self, user_id: Optional[str] = None, org_id: Optional[str] = None, limit: int = 10, hours_back: int = 24
     ) -> List[Conversation]:
         """Get recent conversations across threads."""
         raise NotImplementedError("Cassandra repositories not yet implemented")
 
     async def search_conversations(
-            self, query: str, thread_id: Optional[str] = None, user_id: Optional[str] = None, limit: int = 20
+        self, query: str, thread_id: Optional[str] = None, user_id: Optional[str] = None, limit: int = 20
     ) -> List[Conversation]:
         """Search conversations by content using Cassandra search capabilities."""
         raise NotImplementedError("Cassandra repositories not yet implemented")
 
     async def get_conversation_statistics(
-            self,
-            thread_id: Optional[str] = None,
-            user_id: Optional[str] = None,
-            org_id: Optional[str] = None,
-            start_date: Optional[datetime] = None,
-            end_date: Optional[datetime] = None,
+        self,
+        thread_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+        org_id: Optional[str] = None,
+        start_date: Optional[datetime] = None,
+        end_date: Optional[datetime] = None,
     ) -> Dict[str, Any]:
         """Get conversation statistics."""
         raise NotImplementedError("Cassandra repositories not yet implemented")

--- a/src/cadence/infrastructure/database/repositories/conversation_repository.py
+++ b/src/cadence/infrastructure/database/repositories/conversation_repository.py
@@ -27,7 +27,7 @@ class ConversationRepository(ABC):
 
     @abstractmethod
     async def get_conversation_history(
-            self, thread_id: str, limit: int = 50, before_id: Optional[str] = None
+        self, thread_id: str, limit: int = 50, before_id: Optional[str] = None
     ) -> List[Conversation]:
         """Get conversation history for a thread, ordered by creation time."""
         pass
@@ -39,26 +39,26 @@ class ConversationRepository(ABC):
 
     @abstractmethod
     async def get_recent_conversations(
-            self, user_id: Optional[str] = None, org_id: Optional[str] = None, limit: int = 10, hours_back: int = 24
+        self, user_id: Optional[str] = None, org_id: Optional[str] = None, limit: int = 10, hours_back: int = 24
     ) -> List[Conversation]:
         """Get recent conversation across threads."""
         pass
 
     @abstractmethod
     async def search_conversations(
-            self, query: str, thread_id: Optional[str] = None, user_id: Optional[str] = None, limit: int = 20
+        self, query: str, thread_id: Optional[str] = None, user_id: Optional[str] = None, limit: int = 20
     ) -> List[Conversation]:
         """Search conversation by content."""
         pass
 
     @abstractmethod
     async def get_conversation_statistics(
-            self,
-            thread_id: Optional[str] = None,
-            user_id: Optional[str] = None,
-            org_id: Optional[str] = None,
-            start_date: Optional[datetime] = None,
-            end_date: Optional[datetime] = None,
+        self,
+        thread_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+        org_id: Optional[str] = None,
+        start_date: Optional[datetime] = None,
+        end_date: Optional[datetime] = None,
     ) -> Dict[str, Any]:
         """Get conversation statistics."""
         pass
@@ -92,7 +92,7 @@ class InMemoryConversationRepository(ConversationRepository):
         return self._conversations.get(id)
 
     async def get_conversation_history(
-            self, thread_id: str, limit: int = 50, before_id: Optional[str] = None
+        self, thread_id: str, limit: int = 50, before_id: Optional[str] = None
     ) -> List[Conversation]:
         """Get conversation history for a thread, ordered by creation time."""
         thread_conversations = [conv for conv in self._conversations.values() if conv.thread_id == thread_id]
@@ -113,7 +113,7 @@ class InMemoryConversationRepository(ConversationRepository):
         return sum(1 for conv in self._conversations.values() if conv.thread_id == thread_id)
 
     async def get_recent_conversations(
-            self, user_id: Optional[str] = None, org_id: Optional[str] = None, limit: int = 10, hours_back: int = 24
+        self, user_id: Optional[str] = None, org_id: Optional[str] = None, limit: int = 10, hours_back: int = 24
     ) -> List[Conversation]:
         """Get recent conversations across threads."""
         cutoff_time = datetime.utcnow() - timedelta(hours=hours_back)
@@ -130,7 +130,7 @@ class InMemoryConversationRepository(ConversationRepository):
         return filtered_conversations[:limit]
 
     async def search_conversations(
-            self, query: str, thread_id: Optional[str] = None, user_id: Optional[str] = None, limit: int = 20
+        self, query: str, thread_id: Optional[str] = None, user_id: Optional[str] = None, limit: int = 20
     ) -> List[Conversation]:
         """Search conversations by content."""
         query_lower = query.lower()
@@ -148,12 +148,12 @@ class InMemoryConversationRepository(ConversationRepository):
         return matching_conversations[:limit]
 
     async def get_conversation_statistics(
-            self,
-            thread_id: Optional[str] = None,
-            user_id: Optional[str] = None,
-            org_id: Optional[str] = None,
-            start_date: Optional[datetime] = None,
-            end_date: Optional[datetime] = None,
+        self,
+        thread_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+        org_id: Optional[str] = None,
+        start_date: Optional[datetime] = None,
+        end_date: Optional[datetime] = None,
     ) -> Dict[str, Any]:
         """Get conversation statistics."""
         filtered_conversations = []

--- a/src/cadence/infrastructure/database/repositories/mariadb/mariadb_repositories.py
+++ b/src/cadence/infrastructure/database/repositories/mariadb/mariadb_repositories.py
@@ -51,20 +51,20 @@ class MariaDBThreadRepository(ThreadRepository):
         raise NotImplementedError("MariaDB repositories not yet implemented")
 
     async def list_threads(
-            self,
-            user_id: Optional[str] = None,
-            org_id: Optional[str] = None,
-            status: Optional[ThreadStatus] = None,
-            limit: int = 20,
-            offset: int = 0,
-            sort_by: str = "updated_at",
-            sort_order: str = "desc",
+        self,
+        user_id: Optional[str] = None,
+        org_id: Optional[str] = None,
+        status: Optional[ThreadStatus] = None,
+        limit: int = 20,
+        offset: int = 0,
+        sort_by: str = "updated_at",
+        sort_order: str = "desc",
     ) -> List[Thread]:
         """List threads with filtering and pagination."""
         raise NotImplementedError("MariaDB repositories not yet implemented")
 
     async def count_threads(
-            self, user_id: Optional[str] = None, org_id: Optional[str] = None, status: Optional[ThreadStatus] = None
+        self, user_id: Optional[str] = None, org_id: Optional[str] = None, status: Optional[ThreadStatus] = None
     ) -> int:
         """Count threads matching filters."""
         raise NotImplementedError("MariaDB repositories not yet implemented")
@@ -102,7 +102,7 @@ class MariaDBConversationRepository(ConversationRepository):
         raise NotImplementedError("MariaDB repositories not yet implemented")
 
     async def get_conversation_history(
-            self, thread_id: str, limit: int = 50, before_id: Optional[str] = None
+        self, thread_id: str, limit: int = 50, before_id: Optional[str] = None
     ) -> List[Conversation]:
         """Get conversation history for a thread, ordered by creation time."""
         raise NotImplementedError("MariaDB repositories not yet implemented")
@@ -112,24 +112,24 @@ class MariaDBConversationRepository(ConversationRepository):
         raise NotImplementedError("MariaDB repositories not yet implemented")
 
     async def get_recent_conversations(
-            self, user_id: Optional[str] = None, org_id: Optional[str] = None, limit: int = 10, hours_back: int = 24
+        self, user_id: Optional[str] = None, org_id: Optional[str] = None, limit: int = 10, hours_back: int = 24
     ) -> List[Conversation]:
         """Get recent conversations across threads."""
         raise NotImplementedError("MariaDB repositories not yet implemented")
 
     async def search_conversations(
-            self, query: str, thread_id: Optional[str] = None, user_id: Optional[str] = None, limit: int = 20
+        self, query: str, thread_id: Optional[str] = None, user_id: Optional[str] = None, limit: int = 20
     ) -> List[Conversation]:
         """Search conversations by content using MariaDB full-text search."""
         raise NotImplementedError("MariaDB repositories not yet implemented")
 
     async def get_conversation_statistics(
-            self,
-            thread_id: Optional[str] = None,
-            user_id: Optional[str] = None,
-            org_id: Optional[str] = None,
-            start_date: Optional[datetime] = None,
-            end_date: Optional[datetime] = None,
+        self,
+        thread_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+        org_id: Optional[str] = None,
+        start_date: Optional[datetime] = None,
+        end_date: Optional[datetime] = None,
     ) -> Dict[str, Any]:
         """Get conversation statistics."""
         raise NotImplementedError("MariaDB repositories not yet implemented")

--- a/src/cadence/infrastructure/database/repositories/mongo/mongo_repositories.py
+++ b/src/cadence/infrastructure/database/repositories/mongo/mongo_repositories.py
@@ -53,20 +53,20 @@ class MongoThreadRepository(ThreadRepository):
         raise NotImplementedError("MongoDB repositories not yet implemented")
 
     async def list_threads(
-            self,
-            user_id: Optional[str] = None,
-            org_id: Optional[str] = None,
-            status: Optional[ThreadStatus] = None,
-            limit: int = 20,
-            offset: int = 0,
-            sort_by: str = "updated_at",
-            sort_order: str = "desc",
+        self,
+        user_id: Optional[str] = None,
+        org_id: Optional[str] = None,
+        status: Optional[ThreadStatus] = None,
+        limit: int = 20,
+        offset: int = 0,
+        sort_by: str = "updated_at",
+        sort_order: str = "desc",
     ) -> List[Thread]:
         """List threads with filtering and pagination."""
         raise NotImplementedError("MongoDB repositories not yet implemented")
 
     async def count_threads(
-            self, user_id: Optional[str] = None, org_id: Optional[str] = None, status: Optional[ThreadStatus] = None
+        self, user_id: Optional[str] = None, org_id: Optional[str] = None, status: Optional[ThreadStatus] = None
     ) -> int:
         """Count threads matching filters."""
         raise NotImplementedError("MongoDB repositories not yet implemented")
@@ -105,7 +105,7 @@ class MongoConversationRepository(ConversationRepository):
         raise NotImplementedError("MongoDB repositories not yet implemented")
 
     async def get_conversation_history(
-            self, thread_id: str, limit: int = 50, before_id: Optional[str] = None
+        self, thread_id: str, limit: int = 50, before_id: Optional[str] = None
     ) -> List[Conversation]:
         """Get conversation history for a thread, ordered by creation time."""
         raise NotImplementedError("MongoDB repositories not yet implemented")
@@ -115,24 +115,24 @@ class MongoConversationRepository(ConversationRepository):
         raise NotImplementedError("MongoDB repositories not yet implemented")
 
     async def get_recent_conversations(
-            self, user_id: Optional[str] = None, org_id: Optional[str] = None, limit: int = 10, hours_back: int = 24
+        self, user_id: Optional[str] = None, org_id: Optional[str] = None, limit: int = 10, hours_back: int = 24
     ) -> List[Conversation]:
         """Get recent conversations across threads."""
         raise NotImplementedError("MongoDB repositories not yet implemented")
 
     async def search_conversations(
-            self, query: str, thread_id: Optional[str] = None, user_id: Optional[str] = None, limit: int = 20
+        self, query: str, thread_id: Optional[str] = None, user_id: Optional[str] = None, limit: int = 20
     ) -> List[Conversation]:
         """Search conversations by content using MongoDB Atlas Search."""
         raise NotImplementedError("MongoDB repositories not yet implemented")
 
     async def get_conversation_statistics(
-            self,
-            thread_id: Optional[str] = None,
-            user_id: Optional[str] = None,
-            org_id: Optional[str] = None,
-            start_date: Optional[datetime] = None,
-            end_date: Optional[datetime] = None,
+        self,
+        thread_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+        org_id: Optional[str] = None,
+        start_date: Optional[datetime] = None,
+        end_date: Optional[datetime] = None,
     ) -> Dict[str, Any]:
         """Get conversation statistics using MongoDB aggregation pipelines."""
         raise NotImplementedError("MongoDB repositories not yet implemented")

--- a/src/cadence/infrastructure/database/repositories/postgres/postgresql_repositories.py
+++ b/src/cadence/infrastructure/database/repositories/postgres/postgresql_repositories.py
@@ -86,14 +86,14 @@ class PostgreSQLThreadRepository(ThreadRepository):
             return True
 
     async def list_threads(
-            self,
-            user_id: Optional[str] = None,
-            org_id: Optional[str] = None,
-            status: Optional[ThreadStatus] = None,
-            limit: int = 20,
-            offset: int = 0,
-            sort_by: str = "updated_at",
-            sort_order: str = "desc",
+        self,
+        user_id: Optional[str] = None,
+        org_id: Optional[str] = None,
+        status: Optional[ThreadStatus] = None,
+        limit: int = 20,
+        offset: int = 0,
+        sort_by: str = "updated_at",
+        sort_order: str = "desc",
     ) -> List[Thread]:
         """List threads with filtering and pagination."""
         async with self.session_factory() as session:
@@ -124,7 +124,7 @@ class PostgreSQLThreadRepository(ThreadRepository):
             return [tm.to_domain_model() for tm in thread_models]
 
     async def count_threads(
-            self, user_id: Optional[str] = None, org_id: Optional[str] = None, status: Optional[ThreadStatus] = None
+        self, user_id: Optional[str] = None, org_id: Optional[str] = None, status: Optional[ThreadStatus] = None
     ) -> int:
         """Count threads matching filters."""
         async with self.session_factory() as session:
@@ -260,7 +260,7 @@ class PostgreSQLConversationRepository(ConversationRepository):
             return conversation_model.to_domain_model() if conversation_model else None
 
     async def get_conversation_history(
-            self, thread_id: str, limit: int = 50, before_id: Optional[str] = None
+        self, thread_id: str, limit: int = 50, before_id: Optional[str] = None
     ) -> List[Conversation]:
         """Get conversation history for a thread, ordered by creation time."""
         async with self.session_factory() as session:
@@ -290,7 +290,7 @@ class PostgreSQLConversationRepository(ConversationRepository):
             return result.scalar()
 
     async def get_recent_conversations(
-            self, user_id: Optional[str] = None, org_id: Optional[str] = None, limit: int = 10, hours_back: int = 24
+        self, user_id: Optional[str] = None, org_id: Optional[str] = None, limit: int = 10, hours_back: int = 24
     ) -> List[Conversation]:
         """Get recent conversations across threads."""
         cutoff_time = datetime.utcnow() - timedelta(hours=hours_back)
@@ -313,7 +313,7 @@ class PostgreSQLConversationRepository(ConversationRepository):
             return [cm.to_domain_model() for cm in conversation_models]
 
     async def search_conversations(
-            self, query: str, thread_id: Optional[str] = None, user_id: Optional[str] = None, limit: int = 20
+        self, query: str, thread_id: Optional[str] = None, user_id: Optional[str] = None, limit: int = 20
     ) -> List[Conversation]:
         """Search conversations by content using full-text search."""
         async with self.session_factory() as session:
@@ -339,12 +339,12 @@ class PostgreSQLConversationRepository(ConversationRepository):
             return [cm.to_domain_model() for cm in conversation_models]
 
     async def get_conversation_statistics(
-            self,
-            thread_id: Optional[str] = None,
-            user_id: Optional[str] = None,
-            org_id: Optional[str] = None,
-            start_date: Optional[datetime] = None,
-            end_date: Optional[datetime] = None,
+        self,
+        thread_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+        org_id: Optional[str] = None,
+        start_date: Optional[datetime] = None,
+        end_date: Optional[datetime] = None,
     ) -> Dict[str, Any]:
         """Get conversation statistics."""
         async with self.session_factory() as session:

--- a/src/cadence/infrastructure/database/repositories/redis/conversation_repository.py
+++ b/src/cadence/infrastructure/database/repositories/redis/conversation_repository.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Optional
 import redis.asyncio as redis
 
 from cadence.domain.models import Conversation
+
 from ...repositories.conversation_repository import ConversationRepository
 
 logger = logging.getLogger(__name__)
@@ -86,31 +87,31 @@ class RedisConversationRepository(ConversationRepository):
         return self.conversations_sorted.format(sort_by=sort_by)
 
     async def _queue_conversation_hash_and_ttl(
-            self,
-            pipe,
-            conversation_key: str,
-            conversation_data: Any,
+        self,
+        pipe,
+        conversation_key: str,
+        conversation_data: Any,
     ) -> None:
         """Queue storing the conversation hash and setting TTL."""
         await pipe.hset(conversation_key, mapping=conversation_data)
         await pipe.expire(conversation_key, self.ttl_seconds)
 
     async def _queue_thread_index(
-            self,
-            pipe,
-            thread_key: str,
-            conversation_id: str,
+        self,
+        pipe,
+        thread_key: str,
+        conversation_id: str,
     ) -> None:
         """Queue adding conversation to its thread index and set TTL."""
         await pipe.sadd(thread_key, conversation_id)
         await pipe.expire(thread_key, self.ttl_seconds)
 
     async def _queue_sorted_index(
-            self,
-            pipe,
-            sorted_key: str,
-            member_id: str,
-            score: float,
+        self,
+        pipe,
+        sorted_key: str,
+        member_id: str,
+        score: float,
     ) -> None:
         """Queue adding the conversation to a sorted set and set TTL."""
         await pipe.zadd(sorted_key, {member_id: score})
@@ -136,10 +137,10 @@ class RedisConversationRepository(ConversationRepository):
         await pipe.incr(self.conversation_counter)
 
     async def _queue_delete_conversation_artifacts(
-            self,
-            pipe,
-            conversation: Conversation,
-            sorted_key: str,
+        self,
+        pipe,
+        conversation: Conversation,
+        sorted_key: str,
     ) -> None:
         """Queue deletion of a conversation and all related index entries."""
         conversation_key = self._get_conversation_key(conversation.id)
@@ -231,7 +232,7 @@ class RedisConversationRepository(ConversationRepository):
             return None
 
     async def get_conversation_history(
-            self, thread_id: str, limit: int = 50, before_id: Optional[str] = None
+        self, thread_id: str, limit: int = 50, before_id: Optional[str] = None
     ) -> List[Conversation]:
         """Get conversation history for a thread ordered by creation time.
 
@@ -285,7 +286,7 @@ class RedisConversationRepository(ConversationRepository):
         return await self.redis.scard(thread_key)
 
     async def get_recent_conversations(
-            self, user_id: Optional[str] = None, org_id: Optional[str] = None, limit: int = 10, hours_back: int = 24
+        self, user_id: Optional[str] = None, org_id: Optional[str] = None, limit: int = 10, hours_back: int = 24
     ) -> List[Conversation]:
         """Get recent conversations across threads using Redis sorted sets.
 
@@ -333,7 +334,7 @@ class RedisConversationRepository(ConversationRepository):
         return conversations
 
     async def search_conversations(
-            self, query: str, thread_id: Optional[str] = None, user_id: Optional[str] = None, limit: int = 20
+        self, query: str, thread_id: Optional[str] = None, user_id: Optional[str] = None, limit: int = 20
     ) -> List[Conversation]:
         """Search conversations by content.
 
@@ -380,8 +381,8 @@ class RedisConversationRepository(ConversationRepository):
                     continue
 
                 if (
-                        query_lower in conversation.user_message.lower()
-                        or query_lower in conversation.assistant_message.lower()
+                    query_lower in conversation.user_message.lower()
+                    or query_lower in conversation.assistant_message.lower()
                 ):
                     matching_conversations.append(conversation)
 
@@ -392,12 +393,12 @@ class RedisConversationRepository(ConversationRepository):
         return matching_conversations[:limit]
 
     async def get_conversation_statistics(
-            self,
-            thread_id: Optional[str] = None,
-            user_id: Optional[str] = None,
-            org_id: Optional[str] = None,
-            start_date: Optional[datetime] = None,
-            end_date: Optional[datetime] = None,
+        self,
+        thread_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+        org_id: Optional[str] = None,
+        start_date: Optional[datetime] = None,
+        end_date: Optional[datetime] = None,
     ) -> Dict[str, Any]:
         """Get conversation statistics using Redis operations.
 

--- a/src/cadence/infrastructure/database/repositories/redis/thread_repository.py
+++ b/src/cadence/infrastructure/database/repositories/redis/thread_repository.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Optional
 import redis.asyncio as redis
 
 from cadence.domain.models import Thread, ThreadStatus
+
 from ...repositories.thread_repository import ThreadRepository
 
 logger = logging.getLogger(__name__)
@@ -188,14 +189,14 @@ class RedisThreadRepository(ThreadRepository):
         return True
 
     async def list_threads(
-            self,
-            user_id: Optional[str] = None,
-            org_id: Optional[str] = None,
-            status: Optional[ThreadStatus] = None,
-            limit: int = 20,
-            offset: int = 0,
-            sort_by: str = "updated_at",
-            sort_order: str = "desc",
+        self,
+        user_id: Optional[str] = None,
+        org_id: Optional[str] = None,
+        status: Optional[ThreadStatus] = None,
+        limit: int = 20,
+        offset: int = 0,
+        sort_by: str = "updated_at",
+        sort_order: str = "desc",
     ) -> List[Thread]:
         """List threads with filtering and pagination using Redis sets.
 
@@ -238,7 +239,7 @@ class RedisThreadRepository(ThreadRepository):
         else:
             sorted_thread_ids = await self.redis.zrange(sorted_key, 0, -1)
         filtered_ids = [tid for tid in sorted_thread_ids if tid in thread_ids]
-        paginated_ids = filtered_ids[offset: offset + limit]
+        paginated_ids = filtered_ids[offset : offset + limit]
         threads = []
         for thread_id in paginated_ids:
             thread = await self.get_thread(thread_id)
@@ -248,7 +249,7 @@ class RedisThreadRepository(ThreadRepository):
         return threads
 
     async def count_threads(
-            self, user_id: Optional[str] = None, org_id: Optional[str] = None, status: Optional[ThreadStatus] = None
+        self, user_id: Optional[str] = None, org_id: Optional[str] = None, status: Optional[ThreadStatus] = None
     ) -> int:
         """Count threads matching filters using Redis sets."""
         thread_ids = set()

--- a/src/cadence/infrastructure/database/repositories/thread_repository.py
+++ b/src/cadence/infrastructure/database/repositories/thread_repository.py
@@ -32,21 +32,21 @@ class ThreadRepository(ABC):
 
     @abstractmethod
     async def list_threads(
-            self,
-            user_id: Optional[str] = None,
-            org_id: Optional[str] = None,
-            status: Optional[ThreadStatus] = None,
-            limit: int = 20,
-            offset: int = 0,
-            sort_by: str = "updated_at",
-            sort_order: str = "desc",
+        self,
+        user_id: Optional[str] = None,
+        org_id: Optional[str] = None,
+        status: Optional[ThreadStatus] = None,
+        limit: int = 20,
+        offset: int = 0,
+        sort_by: str = "updated_at",
+        sort_order: str = "desc",
     ) -> List[Thread]:
         """List threads with filtering and pagination."""
         pass
 
     @abstractmethod
     async def count_threads(
-            self, user_id: Optional[str] = None, org_id: Optional[str] = None, status: Optional[ThreadStatus] = None
+        self, user_id: Optional[str] = None, org_id: Optional[str] = None, status: Optional[ThreadStatus] = None
     ) -> int:
         """Count threads matching filters."""
         pass
@@ -97,14 +97,14 @@ class InMemoryThreadRepository(ThreadRepository):
         return True
 
     async def list_threads(
-            self,
-            user_id: Optional[str] = None,
-            org_id: Optional[str] = None,
-            status: Optional[ThreadStatus] = None,
-            limit: int = 20,
-            offset: int = 0,
-            sort_by: str = "updated_at",
-            sort_order: str = "desc",
+        self,
+        user_id: Optional[str] = None,
+        org_id: Optional[str] = None,
+        status: Optional[ThreadStatus] = None,
+        limit: int = 20,
+        offset: int = 0,
+        sort_by: str = "updated_at",
+        sort_order: str = "desc",
     ) -> List[Thread]:
         """List threads with filtering and pagination."""
         filtered_threads = []
@@ -127,10 +127,10 @@ class InMemoryThreadRepository(ThreadRepository):
         else:
             filtered_threads.sort(key=lambda t: t.updated_at, reverse=reverse)
 
-        return filtered_threads[offset: offset + limit]
+        return filtered_threads[offset : offset + limit]
 
     async def count_threads(
-            self, user_id: Optional[str] = None, org_id: Optional[str] = None, status: Optional[ThreadStatus] = None
+        self, user_id: Optional[str] = None, org_id: Optional[str] = None, status: Optional[ThreadStatus] = None
     ) -> int:
         """Count threads matching filters."""
         count = 0

--- a/src/cadence/infrastructure/llm/factory.py
+++ b/src/cadence/infrastructure/llm/factory.py
@@ -10,6 +10,7 @@ from typing import Dict, List, Optional
 from cadence_sdk.base.loggable import Loggable
 from langchain_core.language_models import BaseChatModel
 
+from ...config.settings import Settings
 from .providers import (
     AnthropicProvider,
     AzureOpenAIProvider,
@@ -18,7 +19,6 @@ from .providers import (
     ModelConfig,
     OpenAIProvider,
 )
-from ...config.settings import Settings
 
 
 class ModelCacheManager(Loggable):

--- a/src/cadence/infrastructure/plugins/sdk_manager.py
+++ b/src/cadence/infrastructure/plugins/sdk_manager.py
@@ -81,11 +81,11 @@ class SDKPluginBundle(Loggable):
     """
 
     def __init__(
-            self,
-            contract: BasePlugin,
-            agent,
-            bound_model,
-            tools: List[Tool],
+        self,
+        contract: BasePlugin,
+        agent,
+        bound_model,
+        tools: List[Tool],
     ):
         super().__init__()
         self.contract = contract
@@ -538,12 +538,6 @@ class SDKPluginManager(Loggable):
         self.perform_health_checks()
 
         self.logger.info(f"Plugin reload complete. Loaded {len(self.plugin_bundles)} plugins")
-
-    def _update_tool_hops(self, field: str, increment: int) -> None:
-        """Updates tool hops counter for the tool execution logger."""
-        # This method is called by the ToolExecutionLogger to update tool_hops
-        # The actual state update happens in the graph execution
-        self.logger.debug(f"Tool execution logger requested update: {field} += {increment}")
 
     def _clear_plugin_state(self):
         """Clear all plugin-related state."""

--- a/src/cadence/main.py
+++ b/src/cadence/main.py
@@ -103,7 +103,7 @@ class CadenceApplication:
         self.app = FastAPI(
             title="Cadence 🤖 Multi-agents AI Framework",
             description="A plugin-based multi-agent conversational AI framework",
-            version="1.0.1",
+            version="1.0.2",
             lifespan=lifespan,
         )
 
@@ -123,11 +123,11 @@ class CadenceApplication:
 
         @self.app.get("/health")
         async def health_check():
-            return {"status": "healthy", "message": "Cadence 🤖 Multi-agents AI Framework", "version": "1.0.1"}
+            return {"status": "healthy", "message": "Cadence 🤖 Multi-agents AI Framework", "version": "1.0.2"}
 
         @self.app.get("/")
         async def root():
-            return {"message": "Welcome to Cadence 🤖 Multi-agents AI Framework", "version": "1.0.1", "docs": "/docs"}
+            return {"message": "Welcome to Cadence 🤖 Multi-agents AI Framework", "version": "1.0.2", "docs": "/docs"}
 
         return self.app
 

--- a/src/cadence/ui/__init__.py
+++ b/src/cadence/ui/__init__.py
@@ -17,4 +17,4 @@ __all__ = [
     "__version__",
 ]
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"

--- a/src/cadence/ui/app.py
+++ b/src/cadence/ui/app.py
@@ -58,7 +58,7 @@ def create_api_client(api_base_url: str) -> CadenceApiClient:
 
 
 def send_chat_message(
-        api_client: CadenceApiClient, user_message: str, user_id: str, org_id: str, response_tone: str
+    api_client: CadenceApiClient, user_message: str, user_id: str, org_id: str, response_tone: str
 ) -> ChatResult:
     """Send chat message to API and return response with error handling."""
     try:

--- a/src/cadence/ui/client.py
+++ b/src/cadence/ui/client.py
@@ -58,13 +58,13 @@ class CadenceApiClient:
             return api_response.json()
 
     def chat(
-            self,
-            user_message: str,
-            thread_id: Optional[str] = None,
-            user_id: str = "anonymous",
-            org_id: str = "public",
-            metadata: Optional[Dict[str, Any]] = None,
-            tone: Optional[str] = None,
+        self,
+        user_message: str,
+        thread_id: Optional[str] = None,
+        user_id: str = "anonymous",
+        org_id: str = "public",
+        metadata: Optional[Dict[str, Any]] = None,
+        tone: Optional[str] = None,
     ) -> ChatResult:
         """Send chat message and return assistant response."""
         chat_payload = {


### PR DESCRIPTION
- Remove CADENCE_MAX_TOOL_HOPS configuration and tool_hops tracking
- Consolidate all hop counting logic to agent_hops for simplified state management
- Update routing decisions from END to DONE for consistency
- Remove tool_hops from state updates and hop counting diagrams
- Update documentation to reflect simplified hop counting approach
- Bump version to 1.0.2 across all packages
- Update SDK dependency requirements to >=1.0.2
- Clean up coordinator response enforcement for proper finalizer routing
- Remove tool_hops from ToolExecutionLogger and related infrastructure